### PR TITLE
[Bitbucket] Workspace and Repo selector added

### DIFF
--- a/coverage/historical/bitbucket/historical_coverage_report.py
+++ b/coverage/historical/bitbucket/historical_coverage_report.py
@@ -194,6 +194,7 @@ def prompt_for_workspaces(all_workspaces):
         inquirer.Checkbox('workspaces',
                           message="Select the workspaces to analyze",
                           choices=all_workspaces,
+                          default=all_workspaces,
                           ),
     ]
 
@@ -216,10 +217,12 @@ def prompt_for_repositories(all_repositories):
     """
     Prompt the user to select the repositories they want to analyze using checkboxes.
     """
+    options = [repo['slug'] for repo in all_repositories]
     questions = [
         inquirer.Checkbox('repositories',
                           message="Select the repositories you want to analyze",
-                          choices=[repo['slug'] for repo in all_repositories],
+                          choices=options,
+                          default=options,
                           ),
     ]
 

--- a/coverage/historical/bitbucket/requirements.txt
+++ b/coverage/historical/bitbucket/requirements.txt
@@ -1,1 +1,11 @@
+blessed==1.20.0
+certifi==2023.7.22
+charset-normalizer==2.0.12
+idna==3.4
+inquirer==3.1.3
+python-editor==1.0.4
+readchar==4.0.5
 requests==2.26.0
+six==1.16.0
+urllib3==1.26.18
+wcwidth==0.2.10


### PR DESCRIPTION
With this, when a user runs the script for bitbucket historical coverage, they can choose which workspaces they want to analyse and which repositories they want to analyse in them. 