### PR TITLE
Pagination for get_repositories in Bitbucket

### DIFF
--- a/coverage/historical/bitbucket/historical_coverage_report.py
+++ b/coverage/historical/bitbucket/historical_coverage_report.py
@@ -181,7 +181,7 @@ def get_workspaces(headers):
     """
     Retrieve the list of workspaces for the authenticated user.
     """
-    url = f"{BASE_URL}/workspaces"
+    url = f"{BASE_URL}/workspaces?sort=-updated_on"
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     data = response.json()
@@ -246,11 +246,20 @@ def get_pull_requests(headers, workspace, repo_name):
     """
     Retrieve the list of pull requests for a given repository.
     """
-    url = f"{BASE_URL}/repositories/{workspace}/{repo_name}/pullrequests?state=MERGED"
+    url = f"{BASE_URL}/repositories/{workspace}/{repo_name}/pullrequests?state=MERGED&sort=-updated_on"
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     data = response.json()
-    return data['values']
+    prs = data['values']
+    with tqdm(total=data['size'], initial=len(data['values']), desc=f"    Fetching pull requests") as progress_bar:
+        while 'next' in data:
+            url = data['next']
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            prs.extend(data['values'])
+            progress_bar.update(len(data['values']))
+    return prs
 
 def get_diff(workspace, repo_slug, old_commit_id, new_commit_id, filepath):
     """

--- a/coverage/historical/bitbucket/historical_coverage_report.py
+++ b/coverage/historical/bitbucket/historical_coverage_report.py
@@ -28,6 +28,7 @@ import json
 import base64
 from urllib.parse import quote
 import inquirer
+from tqdm import tqdm
 
 username = "rtapish"
 app_password = "ATBBRrc4kErjKAyBXKXtUTfM5HJB7F388C19"
@@ -211,7 +212,17 @@ def get_repositories(headers, workspace):
     response = requests.get(url, headers=headers)
     response.raise_for_status()
     data = response.json()
-    return [repo for repo in data['values']]
+    repos = data['values']
+    total_repos = data['size']
+    with tqdm(total=total_repos, initial=len(repos), desc=f"  Fetching repos") as progress_bar:
+        while 'next' in data:
+            url = data['next']
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+            repos.extend(data['values'])
+            progress_bar.update(len(data['values']))
+    return repos
 
 def prompt_for_repositories(all_repositories):
     """

--- a/coverage/historical/bitbucket/requirements.txt
+++ b/coverage/historical/bitbucket/requirements.txt
@@ -7,5 +7,6 @@ python-editor==1.0.4
 readchar==4.0.5
 requests==2.26.0
 six==1.16.0
+tqdm==4.66.1
 urllib3==1.26.18
 wcwidth==0.2.10


### PR DESCRIPTION
1. Added pagination for get_repositories in Bitbucket historical coverage script. 
2. Added `tqdm` in requirements.txt of bitbucket
3. Used `tqdm` for showing a progress bar while fetching all repositories
4. Added pagination for pull requests' get call
5. Sorted workspaces and pull requests in reverse order of activity